### PR TITLE
Fixed misleading error message for missing icon.png file

### DIFF
--- a/PKPass.php
+++ b/PKPass.php
@@ -268,7 +268,7 @@ class PKPass {
 		}
 		
 		if(!$hasicon){
-			$this->sError = 'Error while creating pass.pkpass. Check your Zip extension.';
+			$this->sError = 'Missing required icon.png file.';
 			$this->clean();
 			return false;
 		}


### PR DESCRIPTION
If I omitted adding icon.png file when creating a new PKPass, it told me I should check my zip extension, when there was nothing wrong with it.
