### PR TITLE
Support localization

### DIFF
--- a/PKPass.php
+++ b/PKPass.php
@@ -260,10 +260,10 @@ class PKPass {
 		$this->SHAs['pass.json'] = sha1($this->JSON);
 		$hasicon = false;
 		foreach($this->files as $name => $path) {
-			if(strtolower(basename($name)) == 'icon.png'){
+			if(strtolower($name) == 'icon.png'){
 				$hasicon = true;
 			}
-			$this->SHAs[basename($name)] = sha1(file_get_contents($path));
+			$this->SHAs[$name] = sha1(file_get_contents($path));
 			
 		}
 		
@@ -355,7 +355,7 @@ class PKPass {
 		$zip->addFromString('manifest.json',$manifest);
 		$zip->addFromString('pass.json',$this->JSON);
 		foreach($this->files as $name => $path){
-			$zip->addFile($path, basename($name));
+			$zip->addFile($path, $name);
 		}
 		$zip->close();
 		


### PR DESCRIPTION
Fixes issue #25 by not basenaming added files.

Until now, after adding en.lproj/pass.strings, es.lproj/pass.strings et al, the files would be basename-'d when added to the generated zip and while generating the manifest file and hashes.

This would lead to overwriting subsequent filenames with the same name in different directories (for instance, both pass.strings would end on the root directory of the zipfile, the former overwriting the latter). Also, the manifest file would contain just one entry for one of the pass.strings files.
