### PR TITLE
sorry, last change to fix the namespaces :-)

### DIFF
--- a/src/PKPass.php
+++ b/src/PKPass.php
@@ -8,6 +8,7 @@
  * www.tomttb.com
  */
 namespace PKPass;
+use \ZipArchive as ZipArchive;
 
 class PKPass {
 	#################################
@@ -341,7 +342,7 @@ class PKPass {
 		
 		// Package file in Zip (as .pkpass)
 		$zip = new ZipArchive();
-		if(!$zip->open($paths['pkpass'], ZIPARCHIVE::CREATE)) {
+		if(!$zip->open($paths['pkpass'], ZipArchive::CREATE)) {
 			$this->sError = 'Could not open '.basename($paths['pkpass']).' with ZipArchive extension.';
 			return false;
 		}


### PR DESCRIPTION
PHP was not able to resolve the class ZipArchive in the namespaced file without adding this "use" line. (I generated a pass now, so I know its fully functional this way)

Signed-off-by: Elliot Betancourt elliot@elliotbetancourt.com
