### PR TITLE
Fix overzealous cleanup when outputting pass

### DIFF
--- a/PKPass.php
+++ b/PKPass.php
@@ -257,23 +257,19 @@ class PKPass
         }
 
         // Output pass
-        if ($output != true) {
+        if ($output == true) {
 
-            $file = file_get_contents($paths['pkpass']);
-
-            $this->clean();
-
-            return $file;
+            $fileName = ($this->getName()) ? $this->getName() : basename($paths['pkpass']);
+            header('Pragma: no-cache');
+            header('Content-type: application/vnd.apple.pkpass');
+            header('Content-length: ' . filesize($paths['pkpass']));
+            header('Content-Disposition: attachment; filename="' . $fileName . '"');
         }
 
-        $fileName = ($this->getName()) ? $this->getName() : basename($paths['pkpass']);
-        header('Pragma: no-cache');
-        header('Content-type: application/vnd.apple.pkpass');
-        header('Content-length: ' . filesize($paths['pkpass']));
-        header('Content-Disposition: attachment; filename="' . $fileName . '"');
+        $file = file_get_contents($paths['pkpass']);
         $this->clean();
 
-        return file_get_contents($paths['pkpass']);
+        return $file;
     }
 
     /**


### PR DESCRIPTION
When optimizing I accidentally moved the call to `clean()` before I grabbed the contents of the file, resulting in a file not found error when trying to generate the file. 

FIxes

> PHP Warning:  file_get_contents(/tmp/PKPass5705b7db21ea86.72513043/pass.pkpass): failed to open stream: No such file or directory in /var/www/public/vendor/pkpass/pkpass/PKPass.php on line 276
