### PR TITLE
PHPDoc updated for PKPass constructor

### DIFF
--- a/src/PKPass.php
+++ b/src/PKPass.php
@@ -89,9 +89,9 @@ class PKPass
     /**
      * PKPass constructor.
      *
-     * @param bool $certPath
-     * @param bool $certPass
-     * @param bool $JSON
+     * @param string|bool $certPath
+     * @param string|bool $certPass
+     * @param string|bool $JSON
      */
     public function __construct($certPath = false, $certPass = false, $JSON = false)
     {


### PR DESCRIPTION
PKPass constructor has incorrect PHPDoc. Offen IDE or PHP Analyzer is waiting for bool parameter instead of the string.