### PR TITLE
Remote certificates can be used

### DIFF
--- a/src/PKPass.php
+++ b/src/PKPass.php
@@ -125,7 +125,7 @@ class PKPass
      */
     public function setCertificate($path)
     {
-        if(file_exists($path)) {
+        if(@file_get_contents($path)) {
             $this->certPath = $path;
 
             return true;

--- a/src/PKPass.php
+++ b/src/PKPass.php
@@ -117,7 +117,7 @@ class PKPass
     /**
      * Sets the path to a certificate
      * Parameter: string, path to certificate
-     * Return: boolean, true on success, false if file does not exist.
+     * Return: boolean, always true.
      *
      * @param $path
      *
@@ -125,15 +125,9 @@ class PKPass
      */
     public function setCertificate($path)
     {
-        if(@file_get_contents($path)) {
-            $this->certPath = $path;
+        $this->certPath = $path;
 
-            return true;
-        }
-
-        $this->sError = 'Certificate file does not exist.';
-
-        return false;
+        return true;
     }
 
     /**


### PR DESCRIPTION
I changed `file_exists` by `file_get_contents` to fix this issue https://github.com/tschoffelen/php-pkpass/issues/82