### PR TITLE
Use system temp path as default tmp directory

### DIFF
--- a/src/PKPass.php
+++ b/src/PKPass.php
@@ -71,7 +71,7 @@ class PKPass
     protected $wwdrCertPath = '';
 
     /**
-     * Holds the path to a temporary folder.
+     * Holds the path to a temporary folder with trailing slash.
      */
     protected $tempPath;
 

--- a/src/PKPass.php
+++ b/src/PKPass.php
@@ -73,7 +73,7 @@ class PKPass
     /**
      * Holds the path to a temporary folder.
      */
-    protected $tempPath = '/tmp/'; // Must end with slash!
+    protected $tempPath;
 
     /**
      * Holds error info if an error occurred.
@@ -101,6 +101,7 @@ class PKPass
      */
     public function __construct($certPath = false, $certPass = false, $JSON = false)
     {
+        $this->tempPath = sys_get_temp_dir() . '/';  // Must end with slash!
         $this->wwdrCertPath = __DIR__ . '/Certificate/AppleWWDRCA.pem';
 
         if($certPath != false) {


### PR DESCRIPTION
`/tmp/` does not work on all Operation Systems but `sys_get_temp_dir` exist for this use case and does contain a valid temp directory.