### PR TITLE
Escape Locale Strings before adding to array

### DIFF
--- a/src/PKPass.php
+++ b/src/PKPass.php
@@ -237,7 +237,7 @@ class PKPass
         }
         $dictionary = "";
         foreach($strings as $key => $value) {
-            $dictionary .= '"'. $key .'" = "'. $value .'";'. PHP_EOL;
+            $dictionary .= '"'. $this->escapeLocaleString($key) .'" = "'. $this->escapeLocaleString($value) .'";'. PHP_EOL;
         }
         $this->locales[$language] = $dictionary;
 
@@ -664,5 +664,18 @@ class PKPass
         }
 
         return true;
+    }
+
+    protected static $escapeChars = [
+        "\n" => "\\n",
+        "\r" => "\\r",
+        "\"" => "\\\"",
+        "\\" => "\\\\"
+    ];
+    /**
+     * Escapes strings for use in locale files
+     */
+    protected function escapeLocaleString($string) {
+        return strtr($string, self::$escapeChars);
     }
 }

--- a/src/PKPass.php
+++ b/src/PKPass.php
@@ -237,7 +237,7 @@ class PKPass
         }
         $dictionary = "";
         foreach($strings as $key => $value) {
-            $dictionary .= '"'. $this->escapeLocaleString($key) .'" = "'. $this->escapeLocaleString($value) .'";'. PHP_EOL;
+            $dictionary .= '"'. $key .'" = "'. $value .'";'. PHP_EOL;
         }
         $this->locales[$language] = $dictionary;
 
@@ -664,18 +664,5 @@ class PKPass
         }
 
         return true;
-    }
-
-    protected static $escapeChars = [
-        "\n" => "\\n",
-        "\r" => "\\r",
-        "\"" => "\\\"",
-        "\\" => "\\\\"
-    ];
-    /**
-     * Escapes strings for use in locale files
-     */
-    protected function escapeLocaleString($string) {
-        return strtr($string, self::$escapeChars);
     }
 }


### PR DESCRIPTION
When using passes with locale strings containing quote-characters, the strings file is not loaded. The quotes and some other characters needs to be escaped.
This PR escapes both key and value strings in AddLocaleStrings method.

Apple writes the following regarding escaping:

> ### Using Special Characters in String Resources
> Just as in C, some characters must be prefixed with a backslash before you can include them in the string. These characters include double quotation marks, the backslash character itself, and special control characters such as linefeed (\n) and carriage returns (\r).
> https://developer.apple.com/library/archive/documentation/Cocoa/Conceptual/LoadingResources/Strings/Strings.html