### PR TITLE
Fix header size on create action 

### DIFF
--- a/src/PKPass.php
+++ b/src/PKPass.php
@@ -385,7 +385,6 @@ class PKPass
             header('Cache-Control: must-revalidate, post-check=0, pre-check=0');
             header('Last-Modified: ' . gmdate('D, d M Y H:i:s T'));
             header('Pragma: public');
-            header('Content-Length: ' . $size);
             if (ob_get_level() > 0)
             {
                 ob_end_flush();


### PR DESCRIPTION
On https request to create pkpass, the browser still waiting and gives an error on log:
http load failed, 51/20348 bytes buffer

Removing the header('Content-Length: ' . $size); line on PKPass.php works fine with HTTPS.