### PR TITLE
feat: implement PKPassBundle

### DIFF
--- a/docs/PKPassBundle.md
+++ b/docs/PKPassBundle.md
@@ -1,0 +1,186 @@
+# PKPassBundle API Documentation
+
+The `PKPassBundle` class allows you to create a bundle of multiple passes, which can be output as a `.pkpasses` file. This is useful when you need to distribute multiple passes together.
+
+## Table of Contents
+
+- [Constructor](#constructor)
+- [Bundle Management](#bundle-management)
+- [Output Methods](#output-methods)
+- [Constants](#constants)
+
+## Constructor
+
+### `__construct()`
+
+Creates a new PKPassBundle instance.
+
+**Example:**
+```php
+use PKPass\PKPassBundle;
+
+$bundle = new PKPassBundle();
+```
+
+## Bundle Management
+
+### `add(PKPass $pass)`
+
+Adds a pass to the bundle.
+
+**Parameters:**
+- `$pass` (PKPass): A PKPass instance to add to the bundle
+
+**Throws:** `InvalidArgumentException` if the parameter is not a PKPass instance
+
+**Example:**
+```php
+use PKPass\PKPass;
+use PKPass\PKPassBundle;
+
+// Create individual passes
+$pass1 = new PKPass('/path/to/certificate.p12', 'password');
+$pass1->setData($passData1);
+$pass1->addFile('/path/to/icon1.png');
+
+$pass2 = new PKPass('/path/to/certificate.p12', 'password');
+$pass2->setData($passData2);
+$pass2->addFile('/path/to/icon2.png');
+
+// Create bundle and add passes
+$bundle = new PKPassBundle();
+$bundle->add($pass1);
+$bundle->add($pass2);
+```
+
+## Output Methods
+
+### `save($path)`
+
+Saves the bundle as a `.pkpasses` file to the filesystem.
+
+**Parameters:**
+- `$path` (string): File path where the bundle should be saved
+
+**Throws:** `RuntimeException` if the file cannot be written
+
+**Example:**
+```php
+$bundle->save('/path/to/my-passes.pkpasses');
+```
+
+### `output()`
+
+Outputs the bundle as a `.pkpasses` file directly to the browser for download.
+
+This method sets appropriate HTTP headers and streams the file content directly to the browser, then terminates the script with `exit`.
+
+**Headers set:**
+- `Content-Type: application/vnd.apple.pkpasses`
+- `Content-Disposition: attachment; filename="passes.pkpasses"`
+- `Cache-Control: no-cache, no-store, must-revalidate`
+- `Pragma: no-cache`
+
+**Throws:** `RuntimeException` if the stream cannot be created
+
+**Example:**
+```php
+// This will trigger a download in the browser
+$bundle->output();
+// Script execution stops here
+```
+
+## Complete Example
+
+Here's a complete example showing how to create a bundle with multiple passes:
+
+```php
+use PKPass\PKPass;
+use PKPass\PKPassBundle;
+
+try {
+    // Create first pass (boarding pass)
+    $boardingPass = new PKPass('/path/to/certificate.p12', 'password');
+    $boardingPass->setData([
+        'description' => 'Flight Ticket',
+        'formatVersion' => 1,
+        'organizationName' => 'Airline Inc',
+        'passTypeIdentifier' => 'pass.com.airline.boarding',
+        'serialNumber' => 'FLIGHT001',
+        'teamIdentifier' => 'TEAM123',
+        'boardingPass' => [
+            'primaryFields' => [
+                [
+                    'key' => 'destination',
+                    'label' => 'TO',
+                    'value' => 'SFO'
+                ]
+            ]
+        ]
+    ]);
+    $boardingPass->addFile('/path/to/flight-icon.png', 'icon.png');
+
+    // Create second pass (event ticket)
+    $eventPass = new PKPass('/path/to/certificate.p12', 'password');
+    $eventPass->setData([
+        'description' => 'Concert Ticket',
+        'formatVersion' => 1,
+        'organizationName' => 'Music Venue',
+        'passTypeIdentifier' => 'pass.com.venue.event',
+        'serialNumber' => 'EVENT001',
+        'teamIdentifier' => 'TEAM123',
+        'eventTicket' => [
+            'primaryFields' => [
+                [
+                    'key' => 'event',
+                    'label' => 'EVENT',
+                    'value' => 'Rock Concert'
+                ]
+            ]
+        ]
+    ]);
+    $eventPass->addFile('/path/to/concert-icon.png', 'icon.png');
+
+    // Create bundle and add passes
+    $bundle = new PKPassBundle();
+    $bundle->add($boardingPass);
+    $bundle->add($eventPass);
+
+    // Save to file
+    $bundle->save('/path/to/travel-bundle.pkpasses');
+
+    // Or output directly to browser
+    // $bundle->output();
+
+} catch (Exception $e) {
+    echo 'Error creating bundle: ' . $e->getMessage();
+}
+```
+
+## Error Handling
+
+The PKPassBundle class can throw several types of exceptions:
+
+- `InvalidArgumentException`: When trying to add something other than a PKPass instance
+- `RuntimeException`: When ZIP operations fail or file operations fail
+
+Always wrap bundle operations in try-catch blocks:
+
+```php
+try {
+    $bundle = new PKPassBundle();
+    $bundle->add($pass1);
+    $bundle->add($pass2);
+    $bundle->save('/path/to/bundle.pkpasses');
+} catch (InvalidArgumentException $e) {
+    echo 'Invalid pass object: ' . $e->getMessage();
+} catch (RuntimeException $e) {
+    echo 'Bundle creation failed: ' . $e->getMessage();
+}
+```
+
+## File Format
+
+The `.pkpasses` file is a ZIP archive containing multiple `.pkpass` files. Each individual pass in the bundle is a complete, signed pass that could be distributed independently. The bundle format allows iOS to import multiple passes at once when the user opens the `.pkpasses` file.
+
+Note that this format is only supported by iOS Safari. No other browsers or platforms support the `.pkpasses` format for direct import into Apple Wallet.

--- a/examples/bundle.php
+++ b/examples/bundle.php
@@ -1,0 +1,80 @@
+<?php
+
+/**
+ * Simple PKPassBundle example
+ * 
+ * This demonstrates how to create a bundle of multiple passes
+ * and output them as a single .pkpasses file.
+ */
+
+use PKPass\PKPass;
+use PKPass\PKPassBundle;
+
+require('../vendor/autoload.php');
+
+// Create a bundle
+$bundle = new PKPassBundle();
+
+// Create first pass - boarding pass
+$pass1 = new PKPass('../Certificates.p12', 'password');
+$pass1->setData([
+    'description' => 'Flight to London',
+    'formatVersion' => 1,
+    'organizationName' => 'Flight Express',
+    'passTypeIdentifier' => 'pass.com.includable.pkpass-example',
+    'serialNumber' => 'FLIGHT001',
+    'teamIdentifier' => '839X4P2FV8',
+    'boardingPass' => [
+        'primaryFields' => [
+            [
+                'key' => 'origin',
+                'label' => 'San Francisco',
+                'value' => 'SFO',
+            ],
+            [
+                'key' => 'destination',
+                'label' => 'London',
+                'value' => 'LHR',
+            ],
+        ],
+        'transitType' => 'PKTransitTypeAir',
+    ],
+    'barcodes' => [
+        [
+            'format' => 'PKBarcodeFormatQR',
+            'message' => 'Flight-GateF12-ID6643679AH7B',
+            'messageEncoding' => 'iso-8859-1',
+        ]
+    ],
+    'backgroundColor' => 'rgb(32,110,247)'
+]);
+$pass1->addFile('images/icon.png');
+
+// Create second pass - hotel booking
+$pass2 = new PKPass('../Certificates.p12', 'password');
+$pass2->setData([
+    'description' => 'Hotel Reservation',
+    'formatVersion' => 1,
+    'organizationName' => 'London Hotel',
+    'passTypeIdentifier' => 'pass.com.includable.pkpass-example',
+    'serialNumber' => 'HOTEL001',
+    'teamIdentifier' => '839X4P2FV8',
+    'generic' => [
+        'primaryFields' => [
+            ['key' => 'hotel', 'label' => 'Hotel', 'value' => 'London Grand']
+        ],
+        'secondaryFields' => [
+            ['key' => 'checkin', 'label' => 'Check-in', 'value' => 'Nov 7, 2024']
+        ]
+    ],
+    'barcodes' => [['format' => 'PKBarcodeFormatQR', 'message' => 'HOTEL001']],
+    'backgroundColor' => 'rgb(220,20,60)'
+]);
+$pass2->addFile('images/icon.png');
+
+// Add passes to bundle
+$bundle->add($pass1);
+$bundle->add($pass2);
+
+// Output the bundle to browser
+$bundle->output();

--- a/src/PKPassBundle.php
+++ b/src/PKPassBundle.php
@@ -1,0 +1,122 @@
+<?php
+
+namespace PKPass;
+
+use ZipArchive;
+
+/**
+ * A bundle of multiple passes, which can be output as a `.pkpasses` file.
+ */
+class PKPassBundle
+{
+    /**
+     * @var PKPass[]
+     */
+    private $passes = [];
+
+    /**
+     * @var string|null
+     */
+    private $tempFile = null;
+
+    /**
+     * @var string
+     */
+    private $tempPath;
+
+    public function __construct()
+    {
+        $this->tempPath = sys_get_temp_dir();
+    }
+
+    /**
+     * Set the path to the temporary directory.
+     *
+     * @param string $path Path to temporary directory
+     */
+    public function setTempPath($path)
+    {
+        $this->tempPath = $path;
+    }
+
+    /**
+     * Add a pass to the bundle.
+     *
+     * @param PKPass $pass
+     */
+    public function add(PKPass $pass)
+    {
+        if (!($pass instanceof PKPass)) {
+            throw new \InvalidArgumentException('Expected instance of PKPass.');
+        }
+
+        $this->passes[] = $pass;
+    }
+
+    private function createZip(): ZipArchive
+    {
+        if (empty($this->passes)) {
+            throw new \RuntimeException('Cannot create bundle with no passes. Add at least one pass before creating the bundle.');
+        }
+
+        $zip = new ZipArchive();
+        $this->tempFile = tempnam($this->tempPath, 'pkpasses');
+
+        if ($zip->open($this->tempFile, ZipArchive::CREATE | ZipArchive::OVERWRITE) !== true) {
+            throw new \RuntimeException('Could not create zip archive.');
+        }
+
+        $counter = 1;
+        foreach ($this->passes as $pass) {
+            $zip->addFromString("pass{$counter}.pkpass", $pass->create(false));
+            $counter++;
+        }
+
+        if ($zip->close() === false) {
+            throw new \RuntimeException('Could not close zip archive.');
+        }
+
+        // Re-open the zip to read it
+        if ($zip->open($this->tempFile) !== true) {
+            throw new \RuntimeException('Could not reopen zip archive.');
+        }
+
+        return $zip;
+    }
+
+    /**
+     * Save the bundle as a `.pkpasses` file to the filesystem.
+     *
+     * @param string $path
+     */
+    public function save(string $path)
+    {
+        $zip = $this->createZip();
+        $zip->close();
+
+        if (@copy($this->tempFile, $path) === false) {
+            unlink($this->tempFile);
+            throw new \RuntimeException('Could not write zip archive to file.');
+        }
+
+        unlink($this->tempFile);
+    }
+
+    /**
+     * Output the bundle as a `.pkpasses` file to the browser.
+     */
+    public function output()
+    {
+        $zip = $this->createZip();
+        $zip->close();
+
+        header('Content-Type: application/vnd.apple.pkpasses');
+        header('Content-Disposition: attachment; filename="passes.pkpasses"');
+        header('Cache-Control: no-cache, no-store, must-revalidate');
+        header('Pragma: no-cache');
+
+        readfile($this->tempFile);
+        unlink($this->tempFile);
+        exit;
+    }
+}

--- a/tests/PKPassBundleTest.php
+++ b/tests/PKPassBundleTest.php
@@ -1,0 +1,316 @@
+<?php declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+use PKPass\PKPass;
+use PKPass\PKPassBundle;
+use PKPass\PKPassException;
+
+final class PKPassBundleTest extends TestCase
+{
+    private function createSamplePass(): PKPass
+    {
+        $pass = new PKPass(__DIR__ . '/fixtures/example-certificate.p12', 'password');
+        $data = [
+            'description' => 'Test pass',
+            'formatVersion' => 1,
+            'organizationName' => 'Test Organization',
+            'passTypeIdentifier' => 'pass.com.test.example',
+            'serialNumber' => '12345678',
+            'teamIdentifier' => 'KN44X8ZLNC',
+            'barcode' => [
+                'format' => 'PKBarcodeFormatQR',
+                'message' => 'Test-Message',
+                'messageEncoding' => 'iso-8859-1',
+            ],
+            'backgroundColor' => 'rgb(32,110,247)',
+            'logoText' => 'Test Pass',
+            'relevantDate' => date('Y-m-d\TH:i:sP')
+        ];
+        $pass->setData($data);
+        $pass->addFile(__DIR__ . '/fixtures/icon.png');
+        return $pass;
+    }
+
+    private function validateBundle($bundleContent, $expectedPassCount = 1)
+    {
+        // Basic string validation
+        $this->assertIsString($bundleContent);
+        $this->assertGreaterThan(100, strlen($bundleContent));
+
+        // Try to read the ZIP file
+        $tempName = tempnam(sys_get_temp_dir(), 'pkpasses');
+        file_put_contents($tempName, $bundleContent);
+        $zip = new ZipArchive();
+        $res = $zip->open($tempName);
+        $this->assertTrue($res, 'Invalid ZIP file.');
+        $this->assertEquals($expectedPassCount, $zip->numFiles);
+
+        // Validate that each entry is a .pkpass file
+        for ($i = 0; $i < $zip->numFiles; $i++) {
+            $fileName = $zip->getNameIndex($i);
+            $this->assertStringEndsWith('.pkpass', $fileName);
+            $this->assertStringStartsWith('pass', $fileName);
+        }
+
+        $zip->close();
+        unlink($tempName);
+    }
+
+    public function testEmptyBundle()
+    {
+        $bundle = new PKPassBundle();
+        
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Cannot create bundle with no passes. Add at least one pass before creating the bundle.');
+        
+        // Test that createZip method throws an exception when no passes are added
+        $reflection = new ReflectionClass($bundle);
+        $method = $reflection->getMethod('createZip');
+        $method->setAccessible(true);
+        
+        $method->invoke($bundle);
+    }
+
+    public function testSaveEmptyBundle()
+    {
+        $bundle = new PKPassBundle();
+        
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Cannot create bundle with no passes. Add at least one pass before creating the bundle.');
+        
+        $tempFile = tempnam(sys_get_temp_dir(), 'test_bundle') . '.pkpasses';
+        $bundle->save($tempFile);
+    }
+
+    public function testAddSinglePass()
+    {
+        $bundle = new PKPassBundle();
+        $pass = $this->createSamplePass();
+        
+        $bundle->add($pass);
+        
+        // Use reflection to access private passes property
+        $reflection = new ReflectionClass($bundle);
+        $property = $reflection->getProperty('passes');
+        $property->setAccessible(true);
+        $passes = $property->getValue($bundle);
+        
+        $this->assertCount(1, $passes);
+        $this->assertInstanceOf(PKPass::class, $passes[0]);
+    }
+
+    public function testAddMultiplePasses()
+    {
+        $bundle = new PKPassBundle();
+        $pass1 = $this->createSamplePass();
+        $pass2 = $this->createSamplePass();
+        
+        $bundle->add($pass1);
+        $bundle->add($pass2);
+        
+        // Use reflection to access private passes property
+        $reflection = new ReflectionClass($bundle);
+        $property = $reflection->getProperty('passes');
+        $property->setAccessible(true);
+        $passes = $property->getValue($bundle);
+        
+        $this->assertCount(2, $passes);
+        $this->assertInstanceOf(PKPass::class, $passes[0]);
+        $this->assertInstanceOf(PKPass::class, $passes[1]);
+    }
+
+    public function testCreateZipWithSinglePass()
+    {
+        $bundle = new PKPassBundle();
+        $pass = $this->createSamplePass();
+        $bundle->add($pass);
+        
+        $reflection = new ReflectionClass($bundle);
+        $method = $reflection->getMethod('createZip');
+        $method->setAccessible(true);
+        
+        $zip = $method->invoke($bundle);
+        $this->assertInstanceOf(ZipArchive::class, $zip);
+        
+        // Verify the zip contains one pass file
+        $this->assertEquals(1, $zip->numFiles);
+        $this->assertEquals('pass1.pkpass', $zip->getNameIndex(0));
+        
+        $zip->close();
+    }
+
+    public function testCreateZipWithMultiplePasses()
+    {
+        $bundle = new PKPassBundle();
+        $pass1 = $this->createSamplePass();
+        $pass2 = $this->createSamplePass();
+        
+        $bundle->add($pass1);
+        $bundle->add($pass2);
+        
+        $reflection = new ReflectionClass($bundle);
+        $method = $reflection->getMethod('createZip');
+        $method->setAccessible(true);
+        
+        $zip = $method->invoke($bundle);
+        $this->assertInstanceOf(ZipArchive::class, $zip);
+        $this->assertEquals(2, $zip->numFiles);
+        
+        $zip->close();
+    }
+
+    public function testSaveToFile()
+    {
+        $bundle = new PKPassBundle();
+        $pass = $this->createSamplePass();
+        $bundle->add($pass);
+        
+        $tempFile = tempnam(sys_get_temp_dir(), 'test_bundle') . '.pkpasses';
+        
+        try {
+            $bundle->save($tempFile);
+            
+            $this->assertFileExists($tempFile);
+            $content = file_get_contents($tempFile);
+            $this->validateBundle($content, 1);
+        } finally {
+            if (file_exists($tempFile)) {
+                unlink($tempFile);
+            }
+        }
+    }
+
+    public function testSaveMultiplePassesToFile()
+    {
+        $bundle = new PKPassBundle();
+        $pass1 = $this->createSamplePass();
+        $pass2 = $this->createSamplePass();
+        
+        $bundle->add($pass1);
+        $bundle->add($pass2);
+        
+        $tempFile = tempnam(sys_get_temp_dir(), 'test_bundle') . '.pkpasses';
+        
+        try {
+            $bundle->save($tempFile);
+            
+            $this->assertFileExists($tempFile);
+            $content = file_get_contents($tempFile);
+            $this->validateBundle($content, 2);
+        } finally {
+            if (file_exists($tempFile)) {
+                unlink($tempFile);
+            }
+        }
+    }
+
+    public function testSaveToInvalidPath()
+    {
+        $bundle = new PKPassBundle();
+        $pass = $this->createSamplePass();
+        $bundle->add($pass);
+        
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Could not write zip archive to file.');
+        
+        // Try to save to a directory that doesn't exist
+        $bundle->save('/nonexistent/directory/test.pkpasses');
+    }
+
+    public function testOutputHeaders()
+    {
+        $bundle = new PKPassBundle();
+        $pass = $this->createSamplePass();
+        $bundle->add($pass);
+        
+        // Since output() calls exit, we can't test the full method
+        // But we can test that it would work by checking the createZip method
+        $reflection = new ReflectionClass($bundle);
+        $method = $reflection->getMethod('createZip');
+        $method->setAccessible(true);
+        
+        $zip = $method->invoke($bundle);
+        $this->assertNotEmpty($zip->filename, 'Should have a filename');
+        $this->assertFileExists($zip->filename, 'Zip file should exist');
+        
+        $zip->close();
+    }
+
+    public function testBundleNaming()
+    {
+        $bundle = new PKPassBundle();
+        
+        // Add multiple passes to test naming
+        for ($i = 1; $i <= 3; $i++) {
+            $pass = $this->createSamplePass();
+            $bundle->add($pass);
+        }
+        
+        $tempFile = tempnam(sys_get_temp_dir(), 'test_bundle') . '.pkpasses';
+        
+        try {
+            $bundle->save($tempFile);
+            
+            // Open the bundle and check the pass names
+            $zip = new ZipArchive();
+            $zip->open($tempFile);
+            
+            $expectedNames = ['pass1.pkpass', 'pass2.pkpass', 'pass3.pkpass'];
+            for ($i = 0; $i < $zip->numFiles; $i++) {
+                $fileName = $zip->getNameIndex($i);
+                $this->assertContains($fileName, $expectedNames);
+            }
+            
+            $zip->close();
+        } finally {
+            if (file_exists($tempFile)) {
+                unlink($tempFile);
+            }
+        }
+    }
+
+    public function testSetTempPath()
+    {
+        $bundle = new PKPassBundle();
+        $customTempPath = sys_get_temp_dir() . '/custom_pkpass_temp';
+        
+        // Create the custom temp directory
+        if (!is_dir($customTempPath)) {
+            mkdir($customTempPath, 0755, true);
+        }
+        
+        try {
+            $bundle->setTempPath($customTempPath);
+            
+            // Use reflection to verify the temp path was set
+            $reflection = new ReflectionClass($bundle);
+            $property = $reflection->getProperty('tempPath');
+            $property->setAccessible(true);
+            $actualTempPath = $property->getValue($bundle);
+            
+            $this->assertEquals($customTempPath, $actualTempPath);
+            
+            // Test that it actually uses the custom temp path by saving a bundle
+            $pass = $this->createSamplePass();
+            $bundle->add($pass);
+            
+            $tempFile = $customTempPath . '/test_bundle.pkpasses';
+            $bundle->save($tempFile);
+            
+            $this->assertFileExists($tempFile);
+            
+            unlink($tempFile);
+        } finally {
+            // Clean up any remaining files in the custom temp directory
+            $files = glob($customTempPath . '/*');
+            foreach ($files as $file) {
+                unlink($file);
+            }
+            
+            // Clean up the custom temp directory
+            if (is_dir($customTempPath)) {
+                rmdir($customTempPath);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Implements a new class called `PKPassBundle`, which allows you to package multiple passes together and present them at once in Safari:

<img src="https://github.com/user-attachments/assets/6c47692a-3946-4d7f-a694-a8f28e53048a" width="250" />

You can use it like this:

```php
use PKPass\PKPassBundle;

$bundle = new PKPassBundle();
$bundle->add($pass1);
$bundle->add($pass2);

$bundle->output();
```

Fixes #153 