### PR TITLE
Add `setCertificateString` method

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,14 @@ The `key_new.p12` file should now be compatible with OpenSSL v3+.
 
 ## Changelog
 
+**Version 2.5.1 - January 2026**
+
+- Add support for setting the certificate from a string, allowing for more flexible certificate management.
+
+**Version 2.5.0 - September 2025**
+
+- Added `Push` class to handle push notifications for pass updates via APNS.
+
 **Version 2.4.0 - June 2025**
 
 - Add `PKPassBundle` class to bundle multiple passes into a single `.pkpasses` file.

--- a/docs/PKPass.md
+++ b/docs/PKPass.md
@@ -49,6 +49,16 @@ Sets the path to the certificate file.
 $pass->setCertificatePath('/path/to/certificate.p12');
 ```
 
+### `setCertificateString($p12_string)`
+Sets the certificate from a string.
+
+If specified, this overrides any previously set certificate path.
+
+**Parameters:**
+- `$p12_string` (string): The P12 certificate content as a string
+
+**Returns:** `bool` - Always returns true
+
 ### `setCertificatePassword($password)`
 
 Sets the certificate password.

--- a/src/PKPass.php
+++ b/src/PKPass.php
@@ -33,6 +33,12 @@ class PKPass
     protected $certPath;
 
     /**
+     * Holds the certificate content as a string.
+     * @var string
+     */
+    protected $certString;
+
+    /**
      * Name of the downloaded file.
      * @var string
      */
@@ -117,6 +123,21 @@ class PKPass
     public function setCertificatePath($path)
     {
         $this->certPath = $path;
+
+        return true;
+    }
+
+    /**
+     * Sets the certificate from a string.
+     * If specified, this overrides any previously set certificate path.
+     *
+     * @param string $p12_string The P12 certificate content as a string
+     *
+     * @return bool
+     */
+    public function setCertificateString($p12_string)
+    {
+        $this->certString = $p12_string;
 
         return true;
     }
@@ -428,8 +449,10 @@ class PKPass
      */
     protected function readP12()
     {
-        // Use the built-in reader first
-        if (!$pkcs12 = file_get_contents($this->certPath)) {
+        // Use certString if set, otherwise read from file
+        if ($this->certString) {
+            $pkcs12 = $this->certString;
+        } elseif (!$pkcs12 = file_get_contents($this->certPath)) {
             throw new PKPassException('Could not read the certificate.');
         }
         $certs = [];
@@ -455,12 +478,26 @@ class PKPass
 
         // Try an alternative route using shell_exec
         try {
+            // If using certString, write to temp file for shell_exec
+            if ($this->certString) {
+                $certFile = tempnam($this->tempPath, 'pkpass_cert');
+                file_put_contents($certFile, $this->certString);
+            } else {
+                $certFile = $this->certPath;
+            }
+
             $value = @shell_exec(
-                "openssl pkcs12 -in " . escapeshellarg($this->certPath) .
+                "openssl pkcs12 -in " . escapeshellarg($certFile) .
                 " -passin " . escapeshellarg("pass:" . $this->certPass) .
                 " -passout " . escapeshellarg("pass:" . $this->certPass) .
                 " -legacy"
             );
+
+            // Clean up temp file if we created one
+            if ($this->certString && isset($certFile)) {
+                @unlink($certFile);
+            }
+
             if ($value) {
                 $cert = substr($value, strpos($value, '-----BEGIN CERTIFICATE-----'));
                 $cert = substr($cert, 0, strpos($cert, '-----END CERTIFICATE-----') + 25);

--- a/src/PKPass.php
+++ b/src/PKPass.php
@@ -481,7 +481,13 @@ class PKPass
             // If using certString, write to temp file for shell_exec
             if ($this->certString) {
                 $certFile = tempnam($this->tempPath, 'pkpass_cert');
-                file_put_contents($certFile, $this->certString);
+                if ($certFile === false) {
+                    throw new PKPassException('Could not create temporary certificate file.');
+                }
+                $bytesWritten = file_put_contents($certFile, $this->certString);
+                if ($bytesWritten === false) {
+                    throw new PKPassException('Could not write temporary certificate file.');
+                }
             } else {
                 $certFile = $this->certPath;
             }

--- a/tests/BasicTest.php
+++ b/tests/BasicTest.php
@@ -62,4 +62,30 @@ final class BasicTest extends TestCase
             'signature',
         ]);
     }
+
+    public function testSetCertificateString()
+    {
+        $certString = file_get_contents(__DIR__ . '/fixtures/example-certificate.p12');
+
+        $pass = new PKPass();
+        $pass->setCertificateString($certString);
+        $pass->setCertificatePassword('password');
+        $pass->setData([
+            'description' => 'Demo pass',
+            'formatVersion' => 1,
+            'organizationName' => 'Flight Express',
+            'passTypeIdentifier' => 'pass.com.scholica.flights',
+            'serialNumber' => '12345678',
+            'teamIdentifier' => 'KN44X8ZLNC',
+        ]);
+        $pass->addFile(__DIR__ . '/fixtures/icon.png');
+        $value = $pass->create();
+
+        $this->validatePass($value, [
+            'icon.png',
+            'manifest.json',
+            'pass.json',
+            'signature',
+        ]);
+    }
 }


### PR DESCRIPTION
Add option to pass certificate as string instead of file - thanks for the suggestion @nickdnk!

Fixes #158